### PR TITLE
Fix mobile company cards: uniform 2:3 aspect ratio and reduced text spacing

### DIFF
--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -35,14 +35,14 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
         </div>
         
         <div className="mt-10 sm:mt-16">
-          <div className="grid grid-cols-2 md:grid-cols-12 gap-3 md:gap-4 auto-rows-[100px]">
+          <div className="grid grid-cols-2 md:grid-cols-12 gap-3 md:gap-4 md:auto-rows-[100px]">
             {companies.map((company, index) => {
               let gridClass = '';
               
               switch(index) {
                 // Column 1
                 case 0:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-2 row-span-4'; // Large card
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-2 aspect-[3/2]'; // Large card
                   break;
                 case 1:
                   gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-1 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-1 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card
@@ -53,10 +53,10 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
 
                 // Column 2
                 case 3:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1 row-span-4'; // Wide card top
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1 aspect-[2/3]'; // Wide card top
                   break;
                 case 4:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1 row-span-4'; // Wide card middle
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1 aspect-[2/3]'; // Wide card middle
                   break;
                 case 5:
                   gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-5 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-7 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card bottom left
@@ -72,7 +72,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                   gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-11 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-14 col-span-1 aspect-[2/3]'; // Small card top right
                   break;
                 case 9:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-2 row-span-4'; // Large card bottom
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-2 aspect-[3/2]'; // Large card bottom
                   break;
 
                 default:
@@ -117,7 +117,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                             src={company.thumbnail}
                             alt={`${company.name} thumbnail`}
                             fill
-                            className={`object-cover ${isTargetCompany ? 'object-right-top' : ''} transition-transform duration-300 group-hover:scale-110`}
+                            className="object-cover transition-transform duration-300 group-hover:scale-110"
                           />
                         )}
                         <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -42,48 +42,48 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
               switch(index) {
                 // Column 1
                 case 0:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-1'; // Large card
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-2 aspect-[3/2]'; // Large card
                   break;
                 case 1:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-1 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-1 md:row-start-7 col-span-1'; // Small card
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-1 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-1 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card
                   break;
                 case 2:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-3 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-4 md:row-start-7 col-span-1'; // Small card
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-3 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-4 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card
                   break;
 
                 // Column 2
                 case 3:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1'; // Wide card top
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1 aspect-[2/3]'; // Wide card top
                   break;
                 case 4:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1'; // Wide card middle
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1 aspect-[2/3]'; // Wide card middle
                   break;
                 case 5:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-5 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-7 md:row-start-7 col-span-1'; // Small card bottom left
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-5 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-7 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card bottom left
                   break;
                 case 6:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-7 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-10 md:row-start-7 col-span-1'; // Small card top left
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-7 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-10 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card top left
                   break;
                 // Column 3
                 case 7:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-9 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-10 col-span-1'; // Small card top left
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-9 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-10 col-span-1 aspect-[2/3]'; // Small card top left
                   break;
                 case 8:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-11 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-14 col-span-1'; // Small card top right
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-11 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-14 col-span-1 aspect-[2/3]'; // Small card top right
                   break;
                 case 9:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-1'; // Large card bottom
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-2 aspect-[3/2]'; // Large card bottom
                   break;
 
                 default:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 md:col-span-6 md:row-span-4 col-span-1'; // Default small
+                  gridClass = 'lg:col-span-2 lg:row-span-2 md:col-span-6 md:row-span-4 col-span-1 aspect-[2/3]'; // Default small
               }
 
               const cardStyles = `
                 group cursor-pointer transform transition-all duration-300
                 hover:scale-[1.02] hover:shadow-xl active:scale-[0.98]
                 relative overflow-hidden bg-card rounded-tr-0 rounded-br-3xl rounded-tl-3xl rounded-tl-0
-                aspect-[2/3] md:aspect-auto
+                md:aspect-auto
                 ${gridClass}
               `;
 
@@ -120,10 +120,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                         <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />
                         <div className="absolute inset-0 p-3 md:p-6 flex flex-col justify-end">
                           <div>
-                            <h3 className="font-serif italic text-lg md:text-2xl font-semibold mb-1 md:mb-2 text-white">{company.name}</h3>
-                            <div className="font-mono text-sm text-white/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                              Click to view details
-                            </div>
+                            <h3 className="font-serif italic text-lg md:text-2xl font-semibold text-white">{company.name}</h3>
                           </div>
                         </div>
                       </div>

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -101,6 +101,9 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                 urlName: project.urlName || '',
               }))
 
+              const objectTopRightIndices = new Set([0, 1, 2, 3, 6, 7])
+              const imagePositionClass = objectTopRightIndices.has(index) ? 'object-cover object-right-top' : 'object-cover'
+
               return (
                 <Sheet key={company.id}>
                   <SheetTrigger asChild onClick={() => {
@@ -117,7 +120,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                             src={company.thumbnail}
                             alt={`${company.name} thumbnail`}
                             fill
-                            className="object-cover transition-transform duration-300 group-hover:scale-110"
+                            className={`${imagePositionClass} transition-transform duration-300 group-hover:scale-110`}
                           />
                         )}
                         <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -35,54 +35,55 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
         </div>
         
         <div className="mt-10 sm:mt-16">
-          <div className="grid grid-cols-2 md:grid-cols-12 gap-4 auto-rows-[100px]">
+          <div className="grid grid-cols-2 md:grid-cols-12 gap-3 md:gap-4 md:auto-rows-[100px]">
             {companies.map((company, index) => {
               let gridClass = '';
               
               switch(index) {
                 // Column 1
                 case 0:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-2 row-span-4'; // Large card
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-1'; // Large card
                   break;
                 case 1:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-1 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-1 md:row-start-7 col-span-1 row-span-3'; // Small card
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-1 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-1 md:row-start-7 col-span-1'; // Small card
                   break;
                 case 2:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-3 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-4 md:row-start-7 col-span-1 row-span-3'; // Small card
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-3 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-4 md:row-start-7 col-span-1'; // Small card
                   break;
 
                 // Column 2
                 case 3:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1 row-span-4'; // Wide card top
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1'; // Wide card top
                   break;
                 case 4:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1 row-span-4'; // Wide card middle
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1'; // Wide card middle
                   break;
                 case 5:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-5 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-7 md:row-start-7 col-span-1 row-span-3'; // Small card bottom left
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-5 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-7 md:row-start-7 col-span-1'; // Small card bottom left
                   break;
                 case 6:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-7 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-10 md:row-start-7 col-span-1 row-span-3'; // Small card top left
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-7 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-10 md:row-start-7 col-span-1'; // Small card top left
                   break;
                 // Column 3
                 case 7:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-9 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-10 col-span-1 row-span-3'; // Small card top left
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-9 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-10 col-span-1'; // Small card top left
                   break;
                 case 8:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-11 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-14 col-span-1 row-span-3'; // Small card top right
+                  gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-11 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-14 col-span-1'; // Small card top right
                   break;
                 case 9:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-2 row-span-4'; // Large card bottom
-                  break;  
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-1'; // Large card bottom
+                  break;
 
                 default:
-                  gridClass = 'lg:col-span-2 lg:row-span-2 md:col-span-6 md:row-span-4 col-span-1 row-span-4'; // Default small
+                  gridClass = 'lg:col-span-2 lg:row-span-2 md:col-span-6 md:row-span-4 col-span-1'; // Default small
               }
 
               const cardStyles = `
-                group cursor-pointer transform transition-all duration-300 
-                hover:scale-[1.02] hover:shadow-xl active:scale-[0.98] 
+                group cursor-pointer transform transition-all duration-300
+                hover:scale-[1.02] hover:shadow-xl active:scale-[0.98]
                 relative overflow-hidden bg-card rounded-tr-0 rounded-br-3xl rounded-tl-3xl rounded-tl-0
+                aspect-[2/3] md:aspect-auto
                 ${gridClass}
               `;
 
@@ -117,9 +118,9 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                           />
                         )}
                         <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />
-                        <div className="absolute inset-0 p-6 flex flex-col justify-end">
+                        <div className="absolute inset-0 p-3 md:p-6 flex flex-col justify-end">
                           <div>
-                            <h3 className="font-serif italic text-2xl font-semibold mb-2 text-white">{company.name}</h3>
+                            <h3 className="font-serif italic text-lg md:text-2xl font-semibold mb-1 md:mb-2 text-white">{company.name}</h3>
                             <div className="font-mono text-sm text-white/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                               Click to view details
                             </div>

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -120,15 +120,10 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                             className="object-cover transition-transform duration-300 group-hover:scale-110"
                           />
                         )}
-                        <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80 hidden md:block" />
-                        <div className={`absolute inset-0 ${isTargetCompany ? 'p-3 md:p-6' : 'p-6'} hidden md:flex flex-col justify-end`}>
+                        <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />
+                        <div className={`absolute inset-0 ${isTargetCompany ? 'p-3 md:p-6' : 'p-6'} flex flex-col justify-end`}>
                           <div>
-                            <h3 className={`font-serif italic ${isTargetCompany ? 'text-lg md:text-2xl' : 'text-2xl'} font-semibold ${isTargetCompany ? '' : 'mb-2'} text-white`}>{company.name}</h3>
-                            {!isTargetCompany && (
-                              <div className="font-mono text-sm text-white/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                                Click to view details
-                              </div>
-                            )}
+                            <h3 className={`font-serif italic ${isTargetCompany ? 'text-lg md:text-2xl' : 'text-2xl'} font-semibold text-white`}>{company.name}</h3>
                           </div>
                         </div>
                       </div>

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -114,7 +114,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                             src={company.thumbnail}
                             alt={`${company.name} thumbnail`}
                             fill
-                            className="object-cover transition-transform duration-300 group-hover:scale-110"
+                            className="object-cover object-right-top transition-transform duration-300 group-hover:scale-110"
                           />
                         )}
                         <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -120,8 +120,8 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                             className="object-cover transition-transform duration-300 group-hover:scale-110"
                           />
                         )}
-                        <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />
-                        <div className={`absolute inset-0 ${isTargetCompany ? 'p-3 md:p-6' : 'p-6'} flex flex-col justify-end`}>
+                        <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80 hidden md:block" />
+                        <div className={`absolute inset-0 ${isTargetCompany ? 'p-3 md:p-6' : 'p-6'} hidden md:flex flex-col justify-end`}>
                           <div>
                             <h3 className={`font-serif italic ${isTargetCompany ? 'text-lg md:text-2xl' : 'text-2xl'} font-semibold ${isTargetCompany ? '' : 'mb-2'} text-white`}>{company.name}</h3>
                             {!isTargetCompany && (

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -108,7 +108,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                     setSelectedCompany(company)
                   }}>
                     <Card className={cardStyles}>
-                      <div className="relative w-full h-full bg-muted overflow-hidden">
+                      <div className="absolute inset-0 bg-muted overflow-hidden">
                         {company.thumbnail && (
                           <Image
                             src={company.thumbnail}

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -35,14 +35,14 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
         </div>
         
         <div className="mt-10 sm:mt-16">
-          <div className="grid grid-cols-2 md:grid-cols-12 gap-3 md:gap-4 md:auto-rows-[100px]">
+          <div className="grid grid-cols-2 md:grid-cols-12 gap-3 md:gap-4 auto-rows-[100px]">
             {companies.map((company, index) => {
               let gridClass = '';
               
               switch(index) {
                 // Column 1
                 case 0:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-2 aspect-[3/2]'; // Large card
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-1 lg:row-start-1 md:col-span-6 md:row-span-6 md:col-start-1 md:row-start-1 col-span-2 row-span-4'; // Large card
                   break;
                 case 1:
                   gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-1 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-1 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card
@@ -53,10 +53,10 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
 
                 // Column 2
                 case 3:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1 aspect-[2/3]'; // Wide card top
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-1 col-span-1 row-span-4'; // Wide card top
                   break;
                 case 4:
-                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1 aspect-[2/3]'; // Wide card middle
+                  gridClass = 'lg:col-span-4 lg:row-span-3 lg:col-start-5 lg:row-start-4 md:col-span-6 md:row-span-3 md:col-start-7 md:row-start-4 col-span-1 row-span-4'; // Wide card middle
                   break;
                 case 5:
                   gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-5 lg:row-start-7 md:col-span-3 md:row-span-3 md:col-start-7 md:row-start-7 col-span-1 aspect-[2/3]'; // Small card bottom left
@@ -72,7 +72,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                   gridClass = 'lg:col-span-2 lg:row-span-2 lg:col-start-11 lg:row-start-1 md:col-span-6 md:row-span-3 md:col-start-1 md:row-start-14 col-span-1 aspect-[2/3]'; // Small card top right
                   break;
                 case 9:
-                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-2 aspect-[3/2]'; // Large card bottom
+                  gridClass = 'lg:col-span-4 lg:row-span-6 lg:col-start-9 lg:row-start-3 md:col-span-6 md:row-span-6 md:col-start-7 md:row-start-10 col-span-2 row-span-4'; // Large card bottom
                   break;
 
                 default:
@@ -86,6 +86,9 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                 md:aspect-auto
                 ${gridClass}
               `;
+
+              const targetCompanies = new Set(['Microsoft', '1mg', 'goStops', 'The Manufacturing Project', 'myAIcademy', 'Proffy'])
+              const isTargetCompany = targetCompanies.has(company.name)
 
               // Transform project data for ProjectDisplay component
               const transformedProjects = company.projects.map(project => ({
@@ -108,19 +111,24 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                     setSelectedCompany(company)
                   }}>
                     <Card className={cardStyles}>
-                      <div className="absolute inset-0 bg-muted overflow-hidden">
+                      <div className={isTargetCompany ? "absolute inset-0 bg-muted overflow-hidden" : "relative w-full h-full bg-muted overflow-hidden"}>
                         {company.thumbnail && (
                           <Image
                             src={company.thumbnail}
                             alt={`${company.name} thumbnail`}
                             fill
-                            className="object-cover object-right-top transition-transform duration-300 group-hover:scale-110"
+                            className={`object-cover ${isTargetCompany ? 'object-right-top' : ''} transition-transform duration-300 group-hover:scale-110`}
                           />
                         )}
                         <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/80" />
-                        <div className="absolute inset-0 p-3 md:p-6 flex flex-col justify-end">
+                        <div className={`absolute inset-0 ${isTargetCompany ? 'p-3 md:p-6' : 'p-6'} flex flex-col justify-end`}>
                           <div>
-                            <h3 className="font-serif italic text-lg md:text-2xl font-semibold text-white">{company.name}</h3>
+                            <h3 className={`font-serif italic ${isTargetCompany ? 'text-lg md:text-2xl' : 'text-2xl'} font-semibold ${isTargetCompany ? '' : 'mb-2'} text-white`}>{company.name}</h3>
+                            {!isTargetCompany && (
+                              <div className="font-mono text-sm text-white/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                                Click to view details
+                              </div>
+                            )}
                           </div>
                         </div>
                       </div>

--- a/components/companies-grid.tsx
+++ b/components/companies-grid.tsx
@@ -101,7 +101,7 @@ export function CompaniesGrid({ companies }: CompaniesGridProps) {
                 urlName: project.urlName || '',
               }))
 
-              const objectTopRightIndices = new Set([0, 1, 2, 3, 6, 7])
+              const objectTopRightIndices = new Set([1, 2, 3, 4, 7, 8])
               const imagePositionClass = objectTopRightIndices.has(index) ? 'object-cover object-right-top' : 'object-cover'
 
               return (


### PR DESCRIPTION
- Use aspect-[2/3] on mobile cards instead of fixed row-span heights
- Move auto-rows-[100px] to md+ only so mobile cards size by aspect ratio
- All cards now col-span-1 on mobile for a uniform 2-column grid
- Reduce card overlay padding (p-3) and text size (text-lg) on mobile
- Tighten grid gap to gap-3 on mobile

https://claude.ai/code/session_01M9Hbk4eHG3J9zAWAFwcBCY