### PR TITLE
Add Vismay engine section and expand Launched Products

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/app/ai-playbook/content.ts
+++ b/app/ai-playbook/content.ts
@@ -1,4 +1,17 @@
-import { Swatches, CursorClick, Globe, CloudSun, GameController, Cube, AirplaneTilt } from "@phosphor-icons/react"
+import {
+  Swatches,
+  CursorClick,
+  Globe,
+  CloudSun,
+  GameController,
+  Cube,
+  AirplaneTilt,
+  Compass,
+  SoccerBall,
+  FlagCheckered,
+  Lightning,
+  Robot,
+} from "@phosphor-icons/react"
 import { Play } from "@phosphor-icons/react/dist/ssr"
 import type { ElementType } from "react"
 
@@ -12,6 +25,25 @@ export type LinkCardData = {
   iconSource?: string
   accent?: boolean
   users?: number
+}
+
+export type LaunchedProduct = {
+  title: string
+  href: string
+  description: string
+  icon: ElementType
+  accent: string
+  accentSoft: string
+  accentText: string
+  surface: string
+  border: string
+  tags: string[]
+}
+
+export type EngineCapability = {
+  icon: ElementType
+  label: string
+  detail: string
 }
 
 export type RepoStat = {
@@ -135,6 +167,79 @@ export const VIDEO_BRIEF_ITEMS = [
   "Narration scripting and direction",
   "Music and sound design mapped for generation",
   "Generation-ready image and video prompt direction",
+]
+
+// ─── Vismay Engine ────────────────────────────────────────────────
+
+export const VISMAY_CAPABILITIES: EngineCapability[] = [
+  {
+    icon: Cube,
+    label: "Composable viz registry",
+    detail:
+      "Maps, charts, and prose slots dispatched from a single registry — reusable across verticals.",
+  },
+  {
+    icon: Globe,
+    label: "Scroll-driven storytelling",
+    detail:
+      "One scroll position drives Mapbox flights, ECharts step states, and text snap-locks together.",
+  },
+  {
+    icon: Lightning,
+    label: "Markdown + YAML authoring",
+    detail:
+      "Stories authored as MD + YAML, statically generated, themed per-story via CSS variables.",
+  },
+  {
+    icon: Robot,
+    label: "Asset + capture pipeline",
+    detail:
+      "Admin uploader, Compose panel, and capture pipeline shared by every Vismay vertical.",
+  },
+]
+
+// ─── Launched Products ────────────────────────────────────────────
+
+export const LAUNCHED_PRODUCTS: LaunchedProduct[] = [
+  {
+    title: "vizmaya.fyi",
+    href: "https://vizmaya.fyi",
+    description:
+      "Scroll-synced data narratives — Mapbox maps, ECharts visualizations, and prose unified by a single scroll position. 13+ published stories on geopolitics, economics, and technology.",
+    icon: Compass,
+    accent: "#d9a84a",
+    accentSoft: "rgba(217,168,74,0.15)",
+    accentText: "#e4e8f0",
+    surface: "#0d1220",
+    border: "rgba(217,168,74,0.4)",
+    tags: ["13+ stories", "Mapbox GL", "Apache ECharts"],
+  },
+  {
+    title: "footshorts.com",
+    href: "https://footshorts.com",
+    description:
+      "InShorts-style football news — swipeable 60-word AI-summarized cards, follow leagues, teams, and players, with live match context inline. Powered by the same Vismay viz engine.",
+    icon: SoccerBall,
+    accent: "#22c55e",
+    accentSoft: "rgba(34,197,94,0.15)",
+    accentText: "#ecfdf5",
+    surface: "#08120b",
+    border: "rgba(34,197,94,0.4)",
+    tags: ["RN + Next.js", "Gemini summaries", "Hourly ingest"],
+  },
+  {
+    title: "vizf1.com",
+    href: "https://vizf1.com",
+    description:
+      "F1 race storytelling — driver, team, and race discovery pages with editorial stories backed by live timing data. Built on Vismay for charts, maps, and scroll-driven race recaps.",
+    icon: FlagCheckered,
+    accent: "#ef4444",
+    accentSoft: "rgba(239,68,68,0.15)",
+    accentText: "#fef2f2",
+    surface: "#160708",
+    border: "rgba(239,68,68,0.4)",
+    tags: ["Race recaps", "Live timing", "Editorial CMS"],
+  },
 ]
 
 // ─── Repo Stats ───────────────────────────────────────────────────

--- a/app/ai-playbook/page.tsx
+++ b/app/ai-playbook/page.tsx
@@ -21,6 +21,7 @@ import {
   Compass,
   MapTrifold,
   ChartLineUp,
+  Stack,
 } from "@phosphor-icons/react"
 import {
   COLOR_PALETTE,
@@ -34,6 +35,8 @@ import {
   TOTAL_COMMITS,
   TOTAL_LINES_ADDED,
   TOTAL_LINES_REMOVED,
+  VISMAY_CAPABILITIES,
+  LAUNCHED_PRODUCTS,
 } from "./content"
 
 // ─── Animation Variants ───────────────────────────────────────────
@@ -479,95 +482,142 @@ export default function AIPlaybook() {
         </div>
       </Section>
 
+      {/* ── Vismay Engine ─────────────────────────────────── */}
+      <Section id="vismay">
+        <SectionHeading
+          icon={Stack}
+          title="Vismay — The Viz Engine"
+          subtitle="A reusable visualization and storytelling engine. One registry, one scroll model, one asset pipeline — powering three verticals so far."
+        />
+
+        <motion.div variants={fadeUp} className="max-w-4xl mx-auto mb-10">
+          <Card className="group relative overflow-hidden border-[#FAFF00]/40 hover:shadow-2xl transition-all duration-500 hover:-translate-y-1">
+            <div className="absolute inset-0 bg-gradient-to-br from-[#FAFF00]/10 via-transparent to-[#FAFF00]/5" />
+            <CardHeader className="relative">
+              <div className="flex items-center gap-4 mb-2">
+                <div className="w-14 h-14 rounded-2xl bg-[#FAFF00] text-black flex items-center justify-center shrink-0">
+                  <Stack size={28} weight="duotone" />
+                </div>
+                <div className="flex-1">
+                  <CardTitle className="text-2xl">Vismay</CardTitle>
+                  <CardDescription className="text-base">
+                    A monorepo viz engine — registry, slot dispatchers, asset
+                    pipeline, capture pipeline — composed once and reused across
+                    vizmaya.fyi, footshorts.com, and vizf1.com.
+                  </CardDescription>
+                </div>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-3 mt-6">
+                {VISMAY_CAPABILITIES.map(({ icon: Icon, label, detail }) => (
+                  <div
+                    key={label}
+                    className="flex items-start gap-3 p-3 rounded-xl bg-secondary/50 border border-border/50"
+                  >
+                    <div className="w-9 h-9 rounded-lg bg-[#FAFF00]/20 text-[#1A1A1A] dark:text-[#FAFF00] flex items-center justify-center shrink-0">
+                      <Icon size={18} weight="duotone" />
+                    </div>
+                    <div>
+                      <div className="font-semibold text-sm">{label}</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        {detail}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardHeader>
+          </Card>
+        </motion.div>
+      </Section>
+
       {/* ── Launched Products ─────────────────────────────── */}
       <Section id="launched-products">
         <SectionHeading
           icon={Compass}
           title="Launched Products"
-          subtitle="AI-assisted from concept to production — public platforms shipped end-to-end."
+          subtitle="AI-assisted from concept to production — public platforms shipped end-to-end on the Vismay engine."
         />
-        <motion.div variants={fadeUp} className="max-w-3xl mx-auto">
-          <a
-            href="https://vizmaya.fyi"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block"
-          >
-            <Card
-              className="group relative overflow-hidden hover:shadow-2xl transition-all duration-500 hover:-translate-y-1"
-              style={{
-                backgroundColor: "#0d1220",
-                borderColor: "rgba(217,168,74,0.4)",
-              }}
-            >
-              {/* Subtle radial glow */}
-              <div
-                className="absolute inset-0 opacity-40 pointer-events-none"
-                style={{
-                  background:
-                    "radial-gradient(circle at 80% 20%, rgba(217,168,74,0.18) 0%, transparent 55%), radial-gradient(circle at 10% 90%, rgba(79,138,168,0.12) 0%, transparent 50%)",
-                }}
-              />
-              <CardHeader className="relative">
-                <div className="flex items-center gap-4 mb-2">
-                  <div
-                    className="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0"
-                    style={{ backgroundColor: "rgba(217,168,74,0.15)" }}
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.2 }}
+          className="grid md:grid-cols-3 gap-6 max-w-6xl mx-auto"
+        >
+          {LAUNCHED_PRODUCTS.map((product) => {
+            const Icon = product.icon
+            return (
+              <motion.div key={product.title} variants={fadeUp}>
+                <a
+                  href={product.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block h-full"
+                >
+                  <Card
+                    className="group h-full relative overflow-hidden hover:shadow-2xl transition-all duration-500 hover:-translate-y-1"
+                    style={{
+                      backgroundColor: product.surface,
+                      borderColor: product.border,
+                    }}
                   >
-                    <Compass
-                      size={28}
-                      weight="duotone"
-                      style={{ color: "#d9a84a" }}
-                    />
-                  </div>
-                  <div className="flex-1">
-                    <CardTitle
-                      className="text-2xl flex items-center gap-2"
-                      style={{ color: "#e4e8f0" }}
-                    >
-                      vizmaya.fyi
-                      <ArrowSquareOut
-                        size={18}
-                        className="opacity-0 group-hover:opacity-100 transition-opacity"
-                        style={{ color: "#d9a84a" }}
-                      />
-                    </CardTitle>
-                    <CardDescription
-                      className="text-base mt-1"
-                      style={{ color: "rgba(228,232,240,0.7)" }}
-                    >
-                      Scroll-synced data narratives — Mapbox maps, ECharts
-                      visualizations, and prose unified by a single scroll position.
-                      13+ published stories on geopolitics, economics, and
-                      technology.
-                    </CardDescription>
-                  </div>
-                </div>
-
-                {/* Stat chips */}
-                <div className="flex flex-wrap gap-2 mt-4">
-                  {[
-                    { icon: ChartLineUp, label: "13+ stories" },
-                    { icon: MapTrifold, label: "Mapbox GL" },
-                    { icon: Cube, label: "Next.js 16" },
-                  ].map(({ icon: Icon, label }) => (
-                    <span
-                      key={label}
-                      className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full font-medium"
+                    <div
+                      className="absolute inset-0 opacity-40 pointer-events-none"
                       style={{
-                        backgroundColor: "rgba(255,255,255,0.06)",
-                        color: "rgba(228,232,240,0.85)",
-                        border: "1px solid rgba(255,255,255,0.08)",
+                        background: `radial-gradient(circle at 80% 20%, ${product.accentSoft} 0%, transparent 55%), radial-gradient(circle at 10% 90%, rgba(255,255,255,0.05) 0%, transparent 50%)`,
                       }}
-                    >
-                      <Icon size={14} weight="duotone" style={{ color: "#d9a84a" }} />
-                      {label}
-                    </span>
-                  ))}
-                </div>
-              </CardHeader>
-            </Card>
-          </a>
+                    />
+                    <CardHeader className="relative">
+                      <div
+                        className="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0 mb-3"
+                        style={{ backgroundColor: product.accentSoft }}
+                      >
+                        <Icon
+                          size={28}
+                          weight="duotone"
+                          style={{ color: product.accent }}
+                        />
+                      </div>
+                      <CardTitle
+                        className="text-2xl flex items-center gap-2"
+                        style={{ color: product.accentText }}
+                      >
+                        {product.title}
+                        <ArrowSquareOut
+                          size={18}
+                          className="opacity-0 group-hover:opacity-100 transition-opacity"
+                          style={{ color: product.accent }}
+                        />
+                      </CardTitle>
+                      <CardDescription
+                        className="text-base mt-1"
+                        style={{ color: `${product.accentText}b3` }}
+                      >
+                        {product.description}
+                      </CardDescription>
+
+                      <div className="flex flex-wrap gap-2 mt-4">
+                        {product.tags.map((label) => (
+                          <span
+                            key={label}
+                            className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full font-medium"
+                            style={{
+                              backgroundColor: "rgba(255,255,255,0.06)",
+                              color: `${product.accentText}d9`,
+                              border: "1px solid rgba(255,255,255,0.08)",
+                            }}
+                          >
+                            {label}
+                          </span>
+                        ))}
+                      </div>
+                    </CardHeader>
+                  </Card>
+                </a>
+              </motion.div>
+            )
+          })}
         </motion.div>
       </Section>
 

--- a/app/career/content.ts
+++ b/app/career/content.ts
@@ -88,8 +88,8 @@ export const TIMELINE: TimelineRow[] = [
       { phase: "pm",      flex: 1, shortName: "PM + Growth",      shortOpacity: 0.25, shortFontSize: "0.65rem" },
       { phase: "builder", flex: 1, shortName: "Builder & Creative Technologist", shortOpacity: 0.6, shortFontSize: "0.85rem",
         label: "Phase 06 — Today", title: "Builder & Creative Technologist",
-        companies: "Kidzovo  ·  Promad  ·  vizmaya.fyi",
-        skills: ["AI Workflows", "Figma Plugins", "Video Production", "Vibe Building", "Data Storytelling"] },
+        companies: "Kidzovo  ·  Promad  ·  Vismay (vizmaya.fyi · FootShort · vizF1)",
+        skills: ["AI Workflows", "Figma Plugins", "Video Production", "Vibe Building", "Data Storytelling", "Viz Engine"] },
     ],
   },
 ]
@@ -181,6 +181,18 @@ export const SOLUTION_UNITS = [
       "Built vizmaya.fyi — a scroll-synced storytelling platform where Mapbox maps, ECharts visualizations, and prose are driven by a single scroll position. Stories are authored in Markdown + YAML, statically generated, and themed per-story via CSS variables. Maps fly, charts step, and text snap-locks as the reader scrolls.",
     impact: "Dashboards → narratives",
     tools: ["vizmaya.fyi", "Next.js 16", "Mapbox GL", "Apache ECharts", "Supabase"],
+  },
+  {
+    num: "05",
+    accent: "#60A5FA",
+    accentBg: "rgba(96,165,250,0.12)",
+    title: "Vismay — one engine, many verticals",
+    problem:
+      "Once vizmaya.fyi worked, every new domain — football news, F1 racing — wanted the same scroll-driven mechanics. Rebuilding each as a one-off would have meant duplicated maps, duplicated chart steppers, duplicated capture pipelines, and three diverging codebases drifting apart over time.",
+    solution:
+      "Extracted the viz engine into Vismay — a monorepo with a slot registry, dispatchers for maps/charts/prose, a shared asset pipeline, and a capture pipeline. Stories stay in Markdown + YAML, themed per-vertical via CSS variables. The same primitives now power vizmaya.fyi (geopolitics, economics, tech), footshorts.com (InShorts-style football news with AI summaries), and vizf1.com (F1 race recaps and editorial).",
+    impact: "1 engine → 3 live verticals",
+    tools: ["Vismay monorepo", "Slot registry", "Mapbox + ECharts + Next/RN", "Markdown + YAML stories", "Per-vertical theming"],
   },
 ]
 


### PR DESCRIPTION
## Summary

- Adds a new **Vismay — The Viz Engine** section to the AI Playbook page framing Vismay as the underlying viz engine (composable registry, scroll-driven storytelling, MD + YAML authoring, asset + capture pipeline).
- Expands **Launched Products** into a 3-card grid linking [vizmaya.fyi](https://vizmaya.fyi), [footshorts.com](https://footshorts.com), and [vizf1.com](https://vizf1.com), each with its own surface color, accent, and tech chips.
- Adds a 5th `SOLUTION_UNITS` entry on the Career page — **"Vismay — one engine, many verticals"** (`#60A5FA`, impact "1 engine → 3 live verticals") — and updates the Phase 06 timeline box to read `Kidzovo · Promad · Vismay (vizmaya.fyi · FootShort · vizF1)` with a new "Viz Engine" skill chip.

## Why

Vismay now powers three live verticals, so the portfolio needs to reflect both the engine itself and the products built on it. The new AI Playbook section makes the engine concept explicit; the Launched Products grid replaces the single-card vizmaya.fyi treatment now that two more apps are live. On the Career page, the new solution unit captures the leap from a single storytelling product to a reusable platform.

## Notes for reviewers

- All three product URLs were confirmed with the project owner: vizmaya.fyi, footshorts.com, vizf1.com.
- New `LaunchedProduct` and `EngineCapability` types live in `app/ai-playbook/content.ts`; the page consumes them via a single map.
- `app/career/components/SolutionBlock.tsx` is unchanged — it already maps over `SOLUTION_UNITS`, so the new entry renders automatically.
- `.claude/launch.json` gets `autoPort: true` so the local preview server can fall back to a free port when 3000 is busy. No app-side impact.
- Pre-existing React \`key\` warning on the Shipping Product `REPO_STATS` map is unrelated to this change.

## Test plan

- [ ] /ai-playbook — confirm the new "Vismay — The Viz Engine" section renders above "Launched Products" with the four capability tiles.
- [ ] /ai-playbook — Launched Products grid shows vizmaya.fyi, footshorts.com, and vizf1.com with the correct outbound URLs.
- [ ] /career — Solution unit 05 (Vismay) appears with the blue accent and "1 engine → 3 live verticals" impact chip.
- [ ] /career — Phase 06 timeline box reads "Kidzovo · Promad · Vismay (vizmaya.fyi · FootShort · vizF1)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)