### PR TITLE
Render CMS-backed pages dynamically to fix Vercel deploy

### DIFF
--- a/app/companies/[slug]/page.tsx
+++ b/app/companies/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getCompanyBySlug, getCompanies } from '@/lib/payload'
+import { getCompanyBySlug } from '@/lib/payload'
 import { notFound } from 'next/navigation'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -10,15 +10,7 @@ import { Button } from '@/components/ui/button'
 import { ArrowLeft } from '@phosphor-icons/react/dist/ssr'
 import type { Metadata } from 'next'
 
-// Generate static params for all companies at build time
-export async function generateStaticParams() {
-  const companies = await getCompanies()
-  return companies
-    .filter((company) => company.slug)
-    .map((company) => ({
-      slug: company.slug!,
-    }))
-}
+export const dynamic = 'force-dynamic'
 
 // Generate metadata for each company page
 export async function generateMetadata({

--- a/app/companies/page.tsx
+++ b/app/companies/page.tsx
@@ -6,6 +6,8 @@ import { Footer } from '@/components/footer'
 import { Card } from '@/components/ui/card'
 import type { Metadata } from 'next'
 
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: 'Companies | Promad Design',
   description: 'Explore all the companies we have worked with and our contributions to their success.',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,8 @@ import { HighlightBanner } from "@/components/highlight-banner"
 import { VizmayaBanner } from "@/components/vizmaya-banner"
 import { getCompaniesWithProjects } from "@/lib/payload"
 
+export const dynamic = 'force-dynamic'
+
 export default async function Portfolio() {
   // Fetch data from Payload CMS
   const companies = await getCompaniesWithProjects()

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getProjectBySlug, getProjects, type CompanyFromCMS } from '@/lib/payload'
+import { getProjectBySlug, type CompanyFromCMS } from '@/lib/payload'
 import { notFound } from 'next/navigation'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -10,15 +10,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { ArrowLeft, ArrowSquareOut } from '@phosphor-icons/react/dist/ssr'
 import type { Metadata } from 'next'
 
-// Generate static params for all projects at build time
-export async function generateStaticParams() {
-  const projects = await getProjects()
-  return projects
-    .filter((project) => project.slug)
-    .map((project) => ({
-      slug: project.slug!,
-    }))
-}
+export const dynamic = 'force-dynamic'
 
 // Generate metadata for each project page
 export async function generateMetadata({

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -7,6 +7,8 @@ import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import type { Metadata } from 'next'
 
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: 'Projects | Promad Design',
   description: 'Browse all our projects and case studies across various companies and industries.',

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -1,6 +1,8 @@
 import { CompaniesTimeline } from "@/components/companies-timeline"
 import { getCompaniesWithProjects } from "@/lib/payload"
 
+export const dynamic = 'force-dynamic'
+
 export default async function TimelinePage() {
   // Fetch data from Payload CMS
   const companies = await getCompaniesWithProjects()


### PR DESCRIPTION
## Summary

- Vercel build was failing with a Supavisor `FATAL XX000 Max client connections reached` while statically pre-rendering `/projects` (and would have hit the other CMS-backed pages next). Next.js spins up parallel page-build workers, each opens its own Payload→Supabase pool, and the combined connection count blows past the pooler's limit.
- Mark every page that calls Payload at the top level as `dynamic = 'force-dynamic'`, so the DB is queried at request time inside a single warm serverless function instead of at build time. The `revalidatePath` hooks already in [app/payload.config.ts](app/payload.config.ts) keep working — they just refresh the per-request cache instead of build output.
- Drop the now-unused `generateStaticParams` (and their imports) on the `[slug]` pages — with force-dynamic they're dead code.

Files touched:
- [app/page.tsx](app/page.tsx)
- [app/projects/page.tsx](app/projects/page.tsx)
- [app/projects/[slug]/page.tsx](app/projects/[slug]/page.tsx)
- [app/companies/page.tsx](app/companies/page.tsx)
- [app/companies/[slug]/page.tsx](app/companies/[slug]/page.tsx)
- [app/timeline/page.tsx](app/timeline/page.tsx)

## Trade-off

Pages render on every request instead of being baked into static HTML. For a CMS-driven site this is the conventional setup — Vercel's edge cache picks up the slack, and the existing revalidation hooks invalidate it on CMS changes.

## Test plan

- [x] `pnpm build` succeeds locally with an intentionally invalid `DATABASE_URI` — confirms the build no longer requires DB connectivity. Build output shows the six pages marked `ƒ (Dynamic)`.
- [ ] Vercel preview deploy succeeds.
- [ ] `/`, `/projects`, `/projects/[slug]`, `/companies`, `/companies/[slug]`, `/timeline` load with CMS data on the preview.
- [ ] Editing content in the Payload admin still triggers a refresh on the next request (revalidatePath hooks).

## Follow-up worth doing separately

The build-time connection storm is a symptom of an uncapped pool. In [app/payload.config.ts:238](app/payload.config.ts:238) the postgres adapter's pool has no `max` set (defaults to 10) — adding `pool: { connectionString: ..., max: 3 }` would cap each process and reduce pressure on the Supabase pooler at runtime too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)